### PR TITLE
feat: remove automatic icon theme configuration

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,15 +1,7 @@
 const vscode = require('vscode');
 
 function activate(context) {
-    // Set icon theme
-    let disposable = vscode.commands.registerCommand('cool-cowboy-theme.activate', () => {
-        vscode.workspace.getConfiguration().update('workbench.iconTheme', 'vscode-jetbrains-icon-theme-2023-dark', true);
-    });
-
-    context.subscriptions.push(disposable);
-
-    // Run activation command
-    vscode.commands.executeCommand('cool-cowboy-theme.activate');
+    console.log('Cool Cowboy Theme extension is now active!');
 }
 
 module.exports = { activate };

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
     "configuration": {
       "title": "Cool Cowboy Theme",
       "properties": {
-        "workbench.iconTheme": {
-          "type": "string",
-          "default": "vscode-jetbrains-icon-theme-2023-dark",
-          "description": "JetBrains 2023 Dark icons for Cool Cowboy Theme"
-        }
       }
     }
   },
@@ -54,15 +49,6 @@
   ],
   "activationEvents": [
     "onStartupFinished"
-  ],
-  "extensionPack": [
-    "chadalen.vscode-jetbrains-icon-theme"
-  ],
-  "extensionDependencies": [
-    "chadalen.vscode-jetbrains-icon-theme"
-  ],
-  "recommendations": [
-    "chadalen.vscode-jetbrains-icon-theme"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
The extension no longer sets an icon theme by default to give users more flexibility in their UI customization.